### PR TITLE
Display Arxiv Query & Make Savable

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,10 @@
 	"printWidth": 80,
 	"plugins": ["prettier-plugin-svelte"],
 	"pluginSearchDirs": ["."],
-	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }],
+	"svelteSortOrder": "options-scripts-markup-styles",
+	"svelteStrictMode": false,
+	"svelteBracketNewLine": true,
+	"svelteAllowShorthand": true,
+	"svelteIndentScriptAndStyle": true
 }

--- a/by-tomorrow/package.json
+++ b/by-tomorrow/package.json
@@ -14,6 +14,8 @@
 		"db:studio": "drizzle-kit studio"
 	},
 	"devDependencies": {
+		"@melt-ui/pp": "^0.3.2",
+		"@melt-ui/svelte": "^0.86.2",
 		"@sveltejs/adapter-auto": "^3.3.1",
 		"@sveltejs/kit": "^2.15.1",
 		"@sveltejs/vite-plugin-svelte": "^4.0.4",

--- a/by-tomorrow/package.json
+++ b/by-tomorrow/package.json
@@ -34,7 +34,9 @@
 	"dependencies": {
 		"@zerodevx/svelte-json-view": "^1.0.11",
 		"postgres": "^3.4.5",
+		"prettier-plugin-svelte": "^3.3.2",
 		"svelte-radix": "^2.0.1",
+		"title-case": "^4.3.2",
 		"xml-js": "^1.6.11",
 		"zod": "^3.24.1"
 	}

--- a/by-tomorrow/pnpm-lock.yaml
+++ b/by-tomorrow/pnpm-lock.yaml
@@ -30,6 +30,12 @@ importers:
         specifier: ^3.24.1
         version: 3.24.1
     devDependencies:
+      '@melt-ui/pp':
+        specifier: ^0.3.2
+        version: 0.3.2(@melt-ui/svelte@0.86.2(svelte@5.16.0))(svelte@5.16.0)
+      '@melt-ui/svelte':
+        specifier: ^0.86.2
+        version: 0.86.2(svelte@5.16.0)
       '@sveltejs/adapter-auto':
         specifier: ^3.3.1
         version: 3.3.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.16.0)(vite@5.4.11))(svelte@5.16.0)(vite@5.4.11))
@@ -260,6 +266,17 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@melt-ui/pp@0.3.2':
+    resolution: {integrity: sha512-xKkPvaIAFinklLXcQOpwZ8YSpqAFxykjWf8Y/fSJQwsixV/0rcFs07hJ49hJjPy5vItvw5Qa0uOjzFUbXzBypQ==}
+    peerDependencies:
+      '@melt-ui/svelte': '>= 0.29.0'
+      svelte: ^3.55.0 || ^4.0.0 || ^5.0.0-next.1
+
+  '@melt-ui/svelte@0.86.2':
+    resolution: {integrity: sha512-wRVN603oIt1aXvx2QRmKqVDJgTScSvr/WJLLokkD8c4QzHgn6pfpPtUKmhV6Dvkk+OY89OG/1Irkd6ouA50Ztw==}
+    peerDependencies:
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0-next.118
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -555,6 +572,10 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   devalue@5.1.1:
     resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
 
@@ -591,6 +612,9 @@ packages:
   esrap@1.3.2:
     resolution: {integrity: sha512-C4PXusxYhFT98GjLSmb20k9PREuUdporer50dhzGuJu9IJXktbMddVCMLAERl5dAHyAi73GWWCE4FVHGP1794g==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
@@ -609,6 +633,9 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  focus-trap@7.6.2:
+    resolution: {integrity: sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==}
 
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
@@ -757,6 +784,11 @@ packages:
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.0.9:
+    resolution: {integrity: sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   node-releases@2.0.19:
@@ -989,6 +1021,9 @@ packages:
   svelte@5.16.0:
     resolution: {integrity: sha512-Ygqsiac6UogVED2ruKclU+pOeMThxWtp9LG+li7BXeDKC2paVIsRTMkNmcON4Zejerd1s5sZHWx6ZtU85xklVg==}
     engines: {node: '>=18'}
+
+  tabbable@6.2.0:
+    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
@@ -1235,6 +1270,23 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@melt-ui/pp@0.3.2(@melt-ui/svelte@0.86.2(svelte@5.16.0))(svelte@5.16.0)':
+    dependencies:
+      '@melt-ui/svelte': 0.86.2(svelte@5.16.0)
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      svelte: 5.16.0
+
+  '@melt-ui/svelte@0.86.2(svelte@5.16.0)':
+    dependencies:
+      '@floating-ui/core': 1.6.8
+      '@floating-ui/dom': 1.6.12
+      '@internationalized/date': 3.6.0
+      dequal: 2.0.3
+      focus-trap: 7.6.2
+      nanoid: 5.0.9
+      svelte: 5.16.0
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1489,6 +1541,8 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  dequal@2.0.3: {}
+
   devalue@5.1.1: {}
 
   didyoumean@1.2.2: {}
@@ -1537,6 +1591,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.6
+
   fast-glob@3.3.2:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1554,6 +1612,10 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  focus-trap@7.6.2:
+    dependencies:
+      tabbable: 6.2.0
 
   foreground-child@3.3.0:
     dependencies:
@@ -1678,6 +1740,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.8: {}
+
+  nanoid@5.0.9: {}
 
   node-releases@2.0.19: {}
 
@@ -1917,6 +1981,8 @@ snapshots:
       locate-character: 3.0.0
       magic-string: 0.30.17
       zimmerframe: 1.1.2
+
+  tabbable@6.2.0: {}
 
   tailwind-merge@2.6.0: {}
 

--- a/by-tomorrow/pnpm-lock.yaml
+++ b/by-tomorrow/pnpm-lock.yaml
@@ -14,9 +14,15 @@ importers:
       postgres:
         specifier: ^3.4.5
         version: 3.4.5
+      prettier-plugin-svelte:
+        specifier: ^3.3.2
+        version: 3.3.2(prettier@3.4.2)(svelte@5.16.0)
       svelte-radix:
         specifier: ^2.0.1
         version: 2.0.1(svelte@5.16.0)
+      title-case:
+        specifier: ^4.3.2
+        version: 4.3.2
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
@@ -850,6 +856,17 @@ packages:
     resolution: {integrity: sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==}
     engines: {node: '>=12'}
 
+  prettier-plugin-svelte@3.3.2:
+    resolution: {integrity: sha512-kRPjH8wSj2iu+dO+XaUv4vD8qr5mdDmlak3IT/7AOgGIMRG86z/EHOLauFcClKEnOUf4A4nOA7sre5KrJD4Raw==}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+
+  prettier@3.4.2:
+    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -1001,6 +1018,9 @@ packages:
 
   tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
+
+  title-case@4.3.2:
+    resolution: {integrity: sha512-I/nkcBo73mO42Idfv08jhInV61IMb61OdIFxk+B4Gu1oBjWBPOLmhZdsli+oJCVaD+86pYQA93cJfFt224ZFAA==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1732,6 +1752,13 @@ snapshots:
 
   postgres@3.4.5: {}
 
+  prettier-plugin-svelte@3.3.2(prettier@3.4.2)(svelte@5.16.0):
+    dependencies:
+      prettier: 3.4.2
+      svelte: 5.16.0
+
+  prettier@3.4.2: {}
+
   queue-microtask@1.2.3: {}
 
   read-cache@1.0.0:
@@ -1941,6 +1968,8 @@ snapshots:
     dependencies:
       globalyzer: 0.1.0
       globrex: 0.1.2
+
+  title-case@4.3.2: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/by-tomorrow/src/lib/components/arxiv.svelte.ts
+++ b/by-tomorrow/src/lib/components/arxiv.svelte.ts
@@ -1,11 +1,11 @@
 import convert from "xml-js";
 import { validateSchema } from '$lib/utils';
-import type { ArxivQuery, ArxivMetadata} from "$lib/schemas";
+import type { ArxivQuery, ArxivMetadataList} from "$lib/schemas";
 import { arxivResponseSchema } from "$lib/schemas";
 
 export const QUERY_BASE: string = 'https://export.arxiv.org/api/query?';
 
-export async function queryArxiv(query: ArxivQuery): Promise<ArxivMetadata> {
+export async function queryArxiv(query: ArxivQuery): Promise<ArxivMetadataList> {
         let queryStr: string = buildQuery(query);
         const response = await fetch(queryStr);
         if (!response.ok) {
@@ -31,7 +31,7 @@ export async function queryArxiv(query: ArxivQuery): Promise<ArxivMetadata> {
             // Handle validation or parsing errors
             console.error('Error parsing and validating response:', error);
         }
-        return [] as ArxivMetadata;
+        return [] as ArxivMetadataList;
 }
 
 export function buildQuery(params: ArxivQuery): string {

--- a/by-tomorrow/src/lib/components/cardLibrary.svelte
+++ b/by-tomorrow/src/lib/components/cardLibrary.svelte
@@ -1,11 +1,161 @@
 <script lang="ts">
+	import { SvelteSet } from 'svelte/reactivity'
+
+	import { createTagsInput, melt } from '@melt-ui/svelte'
+
+	import { Label } from '$lib/components/ui/label/index.js'
+	import * as Dialog from '$lib/components/ui/dialog'
+	import { Separator } from '$lib/components/ui/separator/index.js'
+
+	import { X } from 'lucide-svelte'
+
 	import type { ArxivMetadataList, ArxivQuery } from './../schemas.ts'
 	import PaperCard from '$lib/components/cards/paperCard.svelte'
+	import Button from './ui/button/button.svelte'
 	let { data, query }: { data: ArxivMetadataList; query: ArxivQuery } = $props()
+
+	// This is a subset of return values
+	const {
+		elements: { root, input, tag, deleteTrigger, edit },
+		states: { tags },
+	} = createTagsInput()
+	let library: SvelteSet<string> = $state(new SvelteSet())
+
+	let selected: SvelteSet<string> = $state(new SvelteSet())
+	function toggleSelected(elemId: string): void {
+		if (selected.has(elemId)) {
+			selected.delete(elemId)
+		} else {
+			selected.add(elemId)
+		}
+		console.log(selected)
+	}
+	function handleCardClick(event: MouseEvent, elemId: string): void {
+		console.log(`Card ${elemId} clicked!`, event)
+		toggleSelected(elemId)
+	}
+	function saveToLibrary() {
+		console.log('Save Selected to Library:', selected)
+		console.log('   used tags:', $tags)
+		library = new SvelteSet([...library, ...selected])
+		selected.clear()
+	}
 </script>
 
-<div class="flex flex-col items-center gap-4">
-	{#each data as metadata (metadata.id)}
-		<PaperCard {metadata} {query} />
-	{/each}
+<div class="flex flex-col gap-4 mt-5 mb-20">
+	<div class="flex flex-row justify-between items-center">
+		<h3 class="text-xl font-bold tracking-tight text-balance">
+			Retrieved Results
+		</h3>
+		<Dialog.Root>
+			<Dialog.Trigger>
+				<Button
+					class={{
+						'font-semibold text-md tracking-normal': true,
+						'bg-indigo-400 hover:bg-indigo-800': selected.size > 0,
+						'pointer-events-none bg-slate-400': selected.size === 0,
+					}}
+					size="sm"
+				>
+					Save Selected to Library
+				</Button>
+			</Dialog.Trigger>
+			<Dialog.Content>
+				<Dialog.Header>
+					<Dialog.Title>Save Papers to Library</Dialog.Title>
+					<Dialog.Description>
+						Verify that you want to save the following papers to your library,
+						and update tags to bulk add to these papers.
+					</Dialog.Description>
+				</Dialog.Header>
+				<Label for="tagInput" class="font-semibold">
+					Bulk Add Tags
+					<div
+						use:melt={$root}
+						id="tagInput"
+						class="flex min-w-[280px] flex-row flex-wrap gap-2.5 rounded-md bg-white px-3 py-2 text-magnum-700
+    focus-within:ring focus-within:ring-magnum-400 border-slate-400 border-1 mt-2"
+					>
+						{#each $tags as t}
+							<div
+								use:melt={$tag(t)}
+								class="flex items-center overflow-hidden rounded-md bg-indigo-100 text-indigo-900 [word-break:break-word]
+      data-[disabled]:bg-indigo-300 data-[selected]:bg-indigo-200 data-[disabled]:hover:cursor-default
+        data-[disabled]:focus:!outline-none data-[disabled]:focus:!ring-0"
+							>
+								<span
+									class="flex items-center font-medium border-r border-indigo-300 py-1 px-1.5"
+									>{t.value}</span
+								>
+								<button
+									use:melt={$deleteTrigger(t)}
+									class="flex h-full items-center px-1 enabled:hover:bg-indigo-300"
+								>
+									<X class="size-3" />
+								</button>
+							</div>
+							<div
+								use:melt={$edit(t)}
+								class="flex items-center overflow-hidden rounded-md px-1.5 [word-break:break-word] data-[invalid-edit]:focus:!ring-red-500"
+							></div>
+						{/each}
+
+						<input
+							use:melt={$input}
+							type="text"
+							placeholder="Enter tags..."
+							class="min-w-[4.5rem] shrink grow basis-0 border-0 font-medium text-black outline-none focus:!ring-0 data-[invalid]:text-red-500"
+						/>
+					</div>
+				</Label>
+				<div class="flex flex-col">
+					<h3 class="text-sm font-semibold">Papers to Save</h3>
+					<div class="flex flex-col gap-2 p-2 mb-4">
+						{#each Array.from(selected) as id}
+							<div
+								class="flex flex-row gap-2 py-1 rounded-sm hover:bg-indigo-100"
+							>
+								<button
+									onclick={() => {
+										toggleSelected(id)
+									}}
+									class="flex h-full items-center px-1"
+								>
+									<X class="size-3" />
+								</button>
+								<span class="text-sm leading-snug">
+									{data.find((m) => m.id === id)?.title}
+								</span>
+							</div>
+						{/each}
+					</div>
+					<Dialog.Close>
+						<Button type="submit" class="text-md" onclick={saveToLibrary}>
+							Save
+						</Button>
+					</Dialog.Close>
+				</div>
+			</Dialog.Content>
+		</Dialog.Root>
+	</div>
+	<div id="cardlib" class="mb-5">
+		{#if data.length > 0}
+			<div class="flex flex-col items-center gap-4">
+				{#each data as metadata (metadata.id)}
+					<PaperCard
+						{metadata}
+						{query}
+						{handleCardClick}
+						selected={selected.has(metadata.id)}
+						library={library.has(metadata.id)}
+					/>
+				{/each}
+			</div>
+		{:else}
+			<div class="p-4 prose-sm bg-slate-50">
+				<p>No Results to Show</p>
+			</div>
+		{/if}
+	</div>
+	<Separator />
 </div>

--- a/by-tomorrow/src/lib/components/cardLibrary.svelte
+++ b/by-tomorrow/src/lib/components/cardLibrary.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import type { ArxivMetadataList, ArxivQuery } from './../schemas.ts'
+	import PaperCard from '$lib/components/cards/paperCard.svelte'
+	let { data, query }: { data: ArxivMetadataList; query: ArxivQuery } = $props()
+</script>
+
+<div class="flex flex-col items-center gap-4">
+	{#each data as metadata (metadata.id)}
+		<PaperCard {metadata} {query} />
+	{/each}
+</div>

--- a/by-tomorrow/src/lib/components/cards/paperCard.svelte
+++ b/by-tomorrow/src/lib/components/cards/paperCard.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card/index'
+	import { Badge } from '$lib/components/ui/badge'
+	import type { ArxivMetadata, ArxivQuery } from '$lib/schemas'
+
+	let { metadata, query }: { metadata: ArxivMetadata; query: ArxivQuery } =
+		$props()
+	let published = new Date(metadata.published)
+</script>
+
+<Card.Root class="w-full relative">
+	<Card.Header>
+		<Card.Title tag="h3" class="text-xl font-bold">{metadata.title}</Card.Title>
+		<Card.Description class="flex flex-col gap-2">
+			{#if metadata.author.length > 0}
+				<div class="flex flex-wrap gap-2">
+					{#each metadata.author as author}
+						<Badge
+							variant={author !== query?.author ? 'outline' : 'default'}
+							class="text-xs text-nowrap">{author}</Badge
+						>
+					{/each}
+				</div>
+			{/if}
+			<span
+				>Published: {published.toLocaleString()},
+				<a class="underline" href={metadata.links['absLink']}
+					>{metadata.links['absLink']}</a
+				>
+			</span>
+		</Card.Description>
+	</Card.Header>
+
+	<Card.Content class="grid">
+		<!-- <p class="text-sm leading-none p-1">{metadata.summary}</p> -->
+		<p
+			class="px-1 text-base leading-relaxed text-pretty font-normal tracking-normal text-gray-700"
+		>
+			{metadata.summary}
+		</p>
+	</Card.Content>
+</Card.Root>

--- a/by-tomorrow/src/lib/components/cards/paperCard.svelte
+++ b/by-tomorrow/src/lib/components/cards/paperCard.svelte
@@ -3,14 +3,41 @@
 	import { Badge } from '$lib/components/ui/badge'
 	import type { ArxivMetadata, ArxivQuery } from '$lib/schemas'
 
-	let { metadata, query }: { metadata: ArxivMetadata; query: ArxivQuery } =
-		$props()
+	let {
+		metadata,
+		query,
+		handleCardClick,
+		selected,
+		library,
+	}: {
+		metadata: ArxivMetadata
+		query: ArxivQuery
+		handleCardClick: (event: MouseEvent, elemId: string) => void
+		selected: boolean
+		library: boolean
+	} = $props()
 	let published = new Date(metadata.published)
 </script>
 
-<Card.Root class="w-full relative">
+<Card.Root
+	class={{
+		'w-full relative': true,
+		'cursor-pointer hover:shadow-xl hover:shadow-slate-400 hover:border-slate-400':
+			!library,
+		'border-4 border-indigo-300 shadow-lg shadow-indigo-200': selected,
+		'border-2 border-emerald-700 border-opacity-50 shadow-sm shadow-emerald-100 bg-emerald-50 bg-opacity-50':
+			library,
+	}}
+	onclick={(event) => {
+		handleCardClick(event, metadata.id)
+	}}
+>
 	<Card.Header>
-		<Card.Title tag="h3" class="text-xl font-bold">{metadata.title}</Card.Title>
+		<Card.Title>
+			<h3 class="text-xl font-bold leading-tight tracking-tight text-pretty">
+				{metadata.title}
+			</h3>
+		</Card.Title>
 		<Card.Description class="flex flex-col gap-2">
 			{#if metadata.author.length > 0}
 				<div class="flex flex-wrap gap-2">
@@ -32,7 +59,6 @@
 	</Card.Header>
 
 	<Card.Content class="grid">
-		<!-- <p class="text-sm leading-none p-1">{metadata.summary}</p> -->
 		<p
 			class="px-1 text-base leading-relaxed text-pretty font-normal tracking-normal text-gray-700"
 		>

--- a/by-tomorrow/src/lib/components/cards/snippetCard.svelte
+++ b/by-tomorrow/src/lib/components/cards/snippetCard.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card/index'
+	import { Badge } from '$lib/components/ui/badge'
+
+	let { title, time, tags, text } = $props()
+</script>
+
+<Card.Root class="w-full relative">
+	<Card.Header>
+		<div class="flex flex-row">
+			<Card.Title tag="h3" class="text-xl font-bold">{title}</Card.Title>
+		</div>
+		<Card.Description class="flex flex-col gap-1">
+			Created: {time.toLocaleString()}
+			{#if tags.length > 0 && tags[0] !== ''}
+				<div class="flex flex-row gap-2">
+					{#each tags as tag}
+						<Badge class="text-xs">{tag}</Badge>
+					{/each}
+				</div>
+			{/if}
+		</Card.Description>
+	</Card.Header>
+
+	<Card.Content class="grid">
+		<p class="text-sm leading-none p-1">{text}</p>
+	</Card.Content>
+</Card.Root>

--- a/by-tomorrow/src/lib/components/deleteAlert.svelte
+++ b/by-tomorrow/src/lib/components/deleteAlert.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import * as AlertDialog from '$lib/components/ui/alert-dialog/index'
+	import { Button } from '$lib/components/ui/button'
+	import { SquareX } from 'lucide-svelte'
+
+	let { onDelete } = $props()
+</script>
+
+<AlertDialog.Root>
+	<AlertDialog.Trigger>
+		<Button
+			variant="ghost"
+			size="icon"
+			class="absolute right-2 top-2 h-6 w-6 rounded-full hover:bg-destructive hover:text-destructive-foreground"
+			><SquareX /></Button
+		>
+	</AlertDialog.Trigger>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Are you absolutely sure?</AlertDialog.Title>
+			<AlertDialog.Description>
+				This action cannot be undone. This will permanently delete your snippet
+				and it cannot be recovered.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Action onclick={() => onDelete()}
+				>Continue</AlertDialog.Action
+			>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { buttonVariants } from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		class: className,
+		ref = $bindable(null),
+		...restProps
+	}: AlertDialogPrimitive.ActionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Action bind:ref class={cn(buttonVariants(), className)} {...restProps} />

--- a/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { buttonVariants } from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		class: className,
+		ref = $bindable(null),
+		...restProps
+	}: AlertDialogPrimitive.CancelProps = $props();
+</script>
+
+<AlertDialogPrimitive.Cancel
+	bind:ref
+	class={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
+	{...restProps}
+/>

--- a/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive, type WithoutChild } from "bits-ui";
+	import AlertDialogOverlay from "./alert-dialog-overlay.svelte";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		portalProps,
+		...restProps
+	}: WithoutChild<AlertDialogPrimitive.ContentProps> & {
+		portalProps?: AlertDialogPrimitive.PortalProps;
+	} = $props();
+</script>
+
+<AlertDialogPrimitive.Portal {...portalProps}>
+	<AlertDialogOverlay />
+	<AlertDialogPrimitive.Content
+		bind:ref
+		class={cn(
+			"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+			className
+		)}
+		{...restProps}
+	/>
+</AlertDialogPrimitive.Portal>

--- a/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
+++ b/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		class: className,
+		ref = $bindable(null),
+		...restProps
+	}: AlertDialogPrimitive.DescriptionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Description
+	bind:ref
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+/>

--- a/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("flex flex-col space-y-2 text-center sm:text-left", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		class: className,
+		ref = $bindable(null),
+		...restProps
+	}: AlertDialogPrimitive.OverlayProps = $props();
+</script>
+
+<AlertDialogPrimitive.Overlay
+	bind:ref
+	class={cn(
+		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+		className
+	)}
+	{...restProps}
+/>

--- a/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
+++ b/by-tomorrow/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		class: className,
+		level = 3,
+		ref = $bindable(null),
+		...restProps
+	}: AlertDialogPrimitive.TitleProps = $props();
+</script>
+
+<AlertDialogPrimitive.Title
+	bind:ref
+	class={cn("text-lg font-semibold", className)}
+	{level}
+	{...restProps}
+/>

--- a/by-tomorrow/src/lib/components/ui/alert-dialog/index.ts
+++ b/by-tomorrow/src/lib/components/ui/alert-dialog/index.ts
@@ -1,0 +1,40 @@
+import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+import Title from "./alert-dialog-title.svelte";
+import Action from "./alert-dialog-action.svelte";
+import Cancel from "./alert-dialog-cancel.svelte";
+import Footer from "./alert-dialog-footer.svelte";
+import Header from "./alert-dialog-header.svelte";
+import Overlay from "./alert-dialog-overlay.svelte";
+import Content from "./alert-dialog-content.svelte";
+import Description from "./alert-dialog-description.svelte";
+
+const Root = AlertDialogPrimitive.Root;
+const Trigger = AlertDialogPrimitive.Trigger;
+const Portal = AlertDialogPrimitive.Portal;
+
+export {
+	Root,
+	Title,
+	Action,
+	Cancel,
+	Portal,
+	Footer,
+	Header,
+	Trigger,
+	Overlay,
+	Content,
+	Description,
+	//
+	Root as AlertDialog,
+	Title as AlertDialogTitle,
+	Action as AlertDialogAction,
+	Cancel as AlertDialogCancel,
+	Portal as AlertDialogPortal,
+	Footer as AlertDialogFooter,
+	Header as AlertDialogHeader,
+	Trigger as AlertDialogTrigger,
+	Overlay as AlertDialogOverlay,
+	Content as AlertDialogContent,
+	Description as AlertDialogDescription,
+};

--- a/by-tomorrow/src/lib/components/ui/badge/badge.svelte
+++ b/by-tomorrow/src/lib/components/ui/badge/badge.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { type Variant, badgeVariants } from "./index.js";
+	import { cn } from "$lib/utils.js";
+
+	let className: string | undefined | null = undefined;
+	export let href: string | undefined = undefined;
+	export let variant: Variant = "default";
+	export { className as class };
+</script>
+
+<svelte:element
+	this={href ? "a" : "span"}
+	{href}
+	class={cn(badgeVariants({ variant, className }))}
+	{...$$restProps}
+>
+	<slot />
+</svelte:element>

--- a/by-tomorrow/src/lib/components/ui/badge/index.ts
+++ b/by-tomorrow/src/lib/components/ui/badge/index.ts
@@ -1,0 +1,22 @@
+import { type VariantProps, tv } from "tailwind-variants";
+
+export { default as Badge } from "./badge.svelte";
+export const badgeVariants = tv({
+	base: "focus:ring-ring inline-flex select-none items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2",
+	variants: {
+		variant: {
+			default:
+				"bg-primary text-primary-foreground hover:bg-primary/80 border-transparent shadow",
+			secondary:
+				"bg-secondary text-secondary-foreground hover:bg-secondary/80 border-transparent",
+			destructive:
+				"bg-destructive text-destructive-foreground hover:bg-destructive/80 border-transparent shadow",
+			outline: "text-foreground",
+		},
+	},
+	defaultVariants: {
+		variant: "default",
+	},
+});
+
+export type Variant = VariantProps<typeof badgeVariants>["variant"];

--- a/by-tomorrow/src/lib/components/ui/button/button.svelte
+++ b/by-tomorrow/src/lib/components/ui/button/button.svelte
@@ -57,7 +57,7 @@
 {#if href}
 	<a
 		bind:this={ref}
-		class={cn(buttonVariants({ variant, size, className }))}
+		class={cn(buttonVariants({ variant, size }), className)}
 		{href}
 		{...restProps}
 	>
@@ -66,7 +66,7 @@
 {:else}
 	<button
 		bind:this={ref}
-		class={cn(buttonVariants({ variant, size, className }))}
+		class={cn(buttonVariants({ variant, size }), className)}
 		{type}
 		{...restProps}
 	>

--- a/by-tomorrow/src/lib/components/ui/dialog/dialog-portal.svelte
+++ b/by-tomorrow/src/lib/components/ui/dialog/dialog-portal.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from "bits-ui";
+
+	type $$Props = DialogPrimitive.PortalProps;
+</script>
+
+<DialogPrimitive.Portal {...$$restProps}>
+	<slot />
+</DialogPrimitive.Portal>

--- a/by-tomorrow/src/routes/search/+page.server.ts
+++ b/by-tomorrow/src/routes/search/+page.server.ts
@@ -1,4 +1,4 @@
-import type { ArxivQuery, ArxivMetadata, SortByType } from "$lib/schemas"
+import type { ArxivQuery, ArxivMetadataList, SortByType } from "$lib/schemas"
 import { queryArxiv } from "$lib/components/arxiv.svelte";
 import type { ActionData } from "./types";
 
@@ -7,7 +7,7 @@ export const actions = {
         const formData = await request.formData();
         let query: ArxivQuery = {
             start: 0,
-            maxResults: Number(formData.get('maxResults')) ?? 2,
+            maxResults: Number(formData.get('maxResults')) ?? 10,
             sortBy: (String(formData.get('sortBy')) ?? 'lastUpdatedDate') as SortByType,
             sortOrder: 'descending',
             author: String(formData.get('queryAuthor')) ?? "Kyunghyun Cho",
@@ -15,7 +15,7 @@ export const actions = {
             ids: String(formData.get('queryId')) ?? "",
             joinType: "AND",
         }
-        let data: ArxivMetadata = await queryArxiv(query);
+        let data: ArxivMetadataList = await queryArxiv(query);
 
         return { success: true, query, data }
     },

--- a/by-tomorrow/src/routes/search/+page.svelte
+++ b/by-tomorrow/src/routes/search/+page.svelte
@@ -1,115 +1,146 @@
 <script lang="ts">
-  import type { ActionData} from "./types.ts";
-  import type { ArxivQuery, ArxivMetadata } from "$lib/schemas"
-  import { enhance } from '$app/forms';
-  import { JsonView } from "@zerodevx/svelte-json-view";
+	import type { ActionData } from './types.ts'
+	import type { ArxivQuery, ArxivMetadataList } from '$lib/schemas'
+	import { enhance } from '$app/forms'
+	import { JsonView } from '@zerodevx/svelte-json-view'
 
-  import * as Select from "$lib/components/ui/select/index.js";
-  import { Button } from "$lib/components/ui/button/index";
-  import { Input } from "$lib/components/ui/input/index";
-  import { Label } from "$lib/components/ui/label/index.js";
+	import * as Select from '$lib/components/ui/select/index.js'
+	import { Separator } from '$lib/components/ui/separator/index.js'
+	import { Button } from '$lib/components/ui/button/index'
+	import { Input } from '$lib/components/ui/input/index'
+	import { Label } from '$lib/components/ui/label/index.js'
 
-  let { form } : { form: ActionData} = $props();
-  const sortByOpts = [
-    { value: "relevance", label: "Relevance" },
-    { value: "lastUpdatedDate", label: "Last Updated" },
-    { value: "submittedDate", label: "Submitted Date" },
-  ]
-  let sortBySelected = $state(form?.query?.sortBy ?? "");
-  let sortByText = $derived(
-    sortByOpts.find((f) => f.value === sortBySelected)?.label ?? "Select an order"
-  );
+	import CardLibrary from '$lib/components/cardLibrary.svelte'
 
+	let { form }: { form: ActionData } = $props()
+	const sortByOpts = [
+		{ value: 'relevance', label: 'Relevance' },
+		{ value: 'lastUpdatedDate', label: 'Last Updated' },
+		{ value: 'submittedDate', label: 'Submitted Date' },
+	]
+	let sortBySelected = $state(form?.query?.sortBy ?? '')
+	let sortByText = $derived(
+		sortByOpts.find((f) => f.value === sortBySelected)?.label ??
+			'Select an order'
+	)
 
-  let resultFeed = $derived(form?.data ?? []);
-  let history: ArxivQuery[] = $state([]);
+	let resultFeed: ArxivMetadataList = $derived(form?.data ?? [])
+	let history: ArxivQuery[] = $state([])
+
+	let data = [
+		{
+			title: 'Paper Title',
+			time: new Date(),
+			tags: ['tag1', 'tag2'],
+			text: 'This is a paper card.',
+		},
+		{
+			title: 'Paper Title 2',
+			time: new Date(),
+			tags: ['tag1', 'tag2'],
+			text: 'This is a paper card 2.',
+		},
+	]
 </script>
 
 <div class="flex h-full flex-1 flex-col items-center px-4">
 	<div
 		class="flex flex-col w-full sm:w-5/6 md:w-4/5 lg:w-3/4 xl:3/5 justify-between space-y-2 gap-4"
 	>
+		<!-- Heading -->
 		<div>
 			<h2 class="text-2xl font-bold tracking-tight text-balance">
 				Arxiv Search
 			</h2>
 			<div class="flex flex-row justify-between gap-4">
 				<p class="text-muted-foreground">
-                    Query the Arxiv API to find interesting papers. Query fields are exact-match only.
+					Query the Arxiv API to find interesting papers. Query fields are
+					exact-match only.
 				</p>
 			</div>
 		</div>
-        <div class="flex flex-col gap-4">
-          <div class="w-full sm:w-5/6 xl:w-2/3 justify-center mx-auto">
-            <form method="POST" use:enhance={() => ({ update }) => update({ reset: false })}>
-              <div class="grid grid-cols-2 gap-2 p-4">
-                  <Label for="queryAuthor">Author</Label>
-                  <Input
-                      id="queryAuthor"
-                      name="queryAuthor"
-                      type="text"
-                      value={form?.query?.author ?? "Kyunghyun Cho"}
-                      />
-                  <Label for="queryTitle">Title</Label>
-                  <Input
-                      id="queryTitle"
-                      name="queryTitle"
-                      type="text"
-                      value={form?.query?.title ?? ""}
-                      />
-                  <Label for="queryId">Article IDs</Label>
-                  <Input
-                      id="queryId"
-                      name="queryId"
-                      type="text"
-                      value={form?.query?.ids ?? ""}
-                      />
-              </div>
-              <div class="flex flex-row gap-2 p-4 justify-center mx-auto">
-                <Label>Max Results:
-                <Input
-                  id="maxResults"
-                  name="maxResults"
-                  type="number"
-                  value={form?.query?.maxResults ?? 2}
-                />
-                </Label>
-                <Label>
-                  Sort By:
-                <Select.Root type="single" name="sortBy" bind:value={sortBySelected}>
-                  <Select.Trigger class="w-[180px]">{sortByText}</Select.Trigger>
-                  <Select.Content>
-                    <Select.Item value="relevance">Relevance</Select.Item>
-                    <Select.Item value="lastUpdatedDate">Last Updated</Select.Item>
-                    <Select.Item value="submittedDate">Submitted Date</Select.Item>
-                  </Select.Content>
-                </Select.Root>
-                </Label>
-              </div>
-              <Button type="submit">
-                  Query Arxiv API
-              </Button>
-            </form>
 
-          </div>
+		<div class="flex flex-col gap-4">
+			<!-- Query Form -->
+			<div class="w-full sm:w-5/6 xl:w-2/3 justify-center mx-auto">
+				<form
+					method="POST"
+					use:enhance={() =>
+						({ update }) =>
+							update({ reset: false })}
+				>
+					<div class="grid grid-cols-6 gap-x-2 gap-y-4 p-2 items-center">
+						<Label class="col-span-1" for="queryAuthor">Author</Label>
+						<Input
+							class="col-span-5"
+							id="queryAuthor"
+							name="queryAuthor"
+							type="text"
+							value={form?.query?.author ?? 'Kyunghyun Cho'}
+						/>
+						<Label class="col-span-1" for="queryTitle">Title</Label>
+						<Input
+							class="col-span-5"
+							id="queryTitle"
+							name="queryTitle"
+							type="text"
+							value={form?.query?.title ?? ''}
+						/>
+						<Label class="col-span-1" for="queryId">Article IDs</Label>
+						<Input
+							class="col-span-5"
+							id="queryId"
+							name="queryId"
+							type="text"
+							value={form?.query?.ids ?? ''}
+						/>
+					</div>
+					<div class="flex flex-row gap-2 p-4 justify-center mx-auto">
+						<Label
+							>Max Results:
+							<Input
+								id="maxResults"
+								name="maxResults"
+								type="number"
+								value={form?.query?.maxResults ?? 10}
+							/>
+						</Label>
+						<Label>
+							Sort By:
+							<Select.Root
+								type="single"
+								name="sortBy"
+								bind:value={sortBySelected}
+							>
+								<Select.Trigger class="w-[180px]">{sortByText}</Select.Trigger>
+								<Select.Content>
+									<Select.Item value="relevance">Relevance</Select.Item>
+									<Select.Item value="lastUpdatedDate">Last Updated</Select.Item
+									>
+									<Select.Item value="submittedDate">Submitted Date</Select.Item
+									>
+								</Select.Content>
+							</Select.Root>
+						</Label>
+					</div>
+					<Button type="submit">Query Arxiv API</Button>
+				</form>
+			</div>
 
-
-            <Label for="results">Retrieved Arxiv Results:</Label>
-            <div id="results">
-              {#if resultFeed.length > 0}
-                <div class="flex flex-col gap-4 w-full prose-sm p-4 bg-slate-50">
-                  {#each resultFeed as entry}
-                    <div class="flex flex-col p-4 gap-2 bg-slate-100">
-                      <JsonView json={entry} />
-                    </div>
-                  {/each}
-                </div>
-              {:else}
-                <div class="p-4 prose-sm bg-slate-50">
-                  <p>No Results to Show</p>
-                </div>
-              {/if}
-            </div>
-          </div>
+			<!-- Card Library -->
+			<div class="flex flex-col gap-4 mb-20">
+				<Label for="cardLib">Retrieved Arxiv Results:</Label>
+				<div id="cardlib" class="mb-5">
+					{#if resultFeed.length > 0}
+						<CardLibrary data={resultFeed} query={form?.query} />
+					{:else}
+						<div class="p-4 prose-sm bg-slate-50">
+							<p>No Results to Show</p>
+						</div>
+					{/if}
+				</div>
+				<Separator />
+			</div>
+		</div>
 	</div>
 </div>

--- a/by-tomorrow/src/routes/search/+page.svelte
+++ b/by-tomorrow/src/routes/search/+page.svelte
@@ -2,7 +2,6 @@
 	import type { ActionData } from './types.ts'
 	import type { ArxivQuery, ArxivMetadataList } from '$lib/schemas'
 	import { enhance } from '$app/forms'
-	import { JsonView } from '@zerodevx/svelte-json-view'
 
 	import * as Select from '$lib/components/ui/select/index.js'
 	import { Separator } from '$lib/components/ui/separator/index.js'
@@ -26,21 +25,6 @@
 
 	let resultFeed: ArxivMetadataList = $derived(form?.data ?? [])
 	let history: ArxivQuery[] = $state([])
-
-	let data = [
-		{
-			title: 'Paper Title',
-			time: new Date(),
-			tags: ['tag1', 'tag2'],
-			text: 'This is a paper card.',
-		},
-		{
-			title: 'Paper Title 2',
-			time: new Date(),
-			tags: ['tag1', 'tag2'],
-			text: 'This is a paper card 2.',
-		},
-	]
 </script>
 
 <div class="flex h-full flex-1 flex-col items-center px-4">
@@ -128,19 +112,7 @@
 			</div>
 
 			<!-- Card Library -->
-			<div class="flex flex-col gap-4 mb-20">
-				<Label for="cardLib">Retrieved Arxiv Results:</Label>
-				<div id="cardlib" class="mb-5">
-					{#if resultFeed.length > 0}
-						<CardLibrary data={resultFeed} query={form?.query} />
-					{:else}
-						<div class="p-4 prose-sm bg-slate-50">
-							<p>No Results to Show</p>
-						</div>
-					{/if}
-				</div>
-				<Separator />
-			</div>
+			<CardLibrary data={resultFeed} query={form?.query} />
 		</div>
 	</div>
 </div>

--- a/by-tomorrow/src/routes/search/types.ts
+++ b/by-tomorrow/src/routes/search/types.ts
@@ -1,7 +1,7 @@
-import type { ArxivMetadata, ArxivQuery } from "$lib/schemas";
+import type { ArxivMetadataList, ArxivQuery } from "$lib/schemas";
 
 export type ActionData = {
     success: boolean,
     query: ArxivQuery,
-    data: ArxivMetadata,
+    data: ArxivMetadataList,
 };

--- a/by-tomorrow/svelte.config.js
+++ b/by-tomorrow/svelte.config.js
@@ -1,12 +1,15 @@
 import adapter from '@sveltejs/adapter-auto';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { preprocessMeltUI, sequence } from '@melt-ui/pp'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	// Consult https://svelte.dev/docs/kit/integrations
 	// for more information about preprocessors
-	preprocess: vitePreprocess(),
-
+	preprocess: sequence([
+		vitePreprocess(),
+		preprocessMeltUI()
+	]),
 	kit: {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.


### PR DESCRIPTION
This incorporated a meltui tags input component, cards from the snippet viewer v0, a bunch of components that should probably be broken into smaller components, display of badges for authors, and much more.

Functionality includes selecting paper cards from the query, saving them to the library with tags, and the UI showing which cards are selected, which cards are in your library, and allowing you to move titles from your selections before saving with tags.

## Final Results

![Screenshot 2025-01-01 at 2 37 10 PM](https://github.com/user-attachments/assets/e61fa780-c2f6-407c-8208-743465d88cc7)

![Screenshot 2025-01-01 at 2 37 26 PM](https://github.com/user-attachments/assets/7858eb26-7eaa-4ec3-a5a7-7287004f3f99)

![Screenshot 2025-01-01 at 2 37 38 PM](https://github.com/user-attachments/assets/049d1207-c611-43ab-b49b-a3a4b3235078)

![Screenshot 2025-01-01 at 2 38 00 PM](https://github.com/user-attachments/assets/ebcb0d7d-9195-45ce-9d77-ef770df0d4ce)

![Screenshot 2025-01-01 at 2 38 12 PM](https://github.com/user-attachments/assets/4d4b2a01-6b22-4506-9164-dbfc66a024c9)

![Screenshot 2025-01-01 at 2 38 27 PM](https://github.com/user-attachments/assets/5bfebd04-37c6-4fad-91cb-fe55c28aa6b0)
