### PR TITLE
Remove .js extensions from internal imports

### DIFF
--- a/src/lib/components/search/cardLibrary.svelte
+++ b/src/lib/components/search/cardLibrary.svelte
@@ -3,9 +3,9 @@
 
 	import { createTagsInput, melt } from '@melt-ui/svelte'
 
-	import { Label } from '$lib/components/ui/label/index.js'
+       import { Label } from '$lib/components/ui/label'
 	import * as Dialog from '$lib/components/ui/dialog'
-	import { Separator } from '$lib/components/ui/separator/index.js'
+       import { Separator } from '$lib/components/ui/separator'
 
 	import { X } from 'lucide-svelte'
 	import logger from '$lib/logger'

--- a/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui'
-	import { buttonVariants } from '$lib/components/ui/button/index.js'
+       import { buttonVariants } from '$lib/components/ui/button'
 	import { cn } from '$lib/utils.js'
 
 	let {

--- a/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui'
-	import { buttonVariants } from '$lib/components/ui/button/index.js'
+       import { buttonVariants } from '$lib/components/ui/button'
 	import { cn } from '$lib/utils.js'
 
 	let {

--- a/src/lib/components/ui/badge/badge.svelte
+++ b/src/lib/components/ui/badge/badge.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { type Variant, badgeVariants } from './index.js'
+       import { type Variant, badgeVariants } from './index'
 	import { cn } from '$lib/utils.js'
 
 	let className: string | undefined | null = undefined

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -5,7 +5,7 @@
 	} from 'bits-ui'
 	import X from 'lucide-svelte/icons/x'
 	import type { Snippet } from 'svelte'
-	import * as Dialog from './index.js'
+       import * as Dialog from './index'
 	import { cn } from '$lib/utils.js'
 
 	let {

--- a/src/lib/components/ui/scroll-area/scroll-area.svelte
+++ b/src/lib/components/ui/scroll-area/scroll-area.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ScrollArea as ScrollAreaPrimitive, type WithoutChild } from 'bits-ui'
-	import { Scrollbar } from './index.js'
+       import { Scrollbar } from './index'
 	import { cn } from '$lib/utils.js'
 
 	let {

--- a/src/lib/components/ui/select/select-content.svelte
+++ b/src/lib/components/ui/select/select-content.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Select as SelectPrimitive, type WithoutChild } from 'bits-ui'
-	import * as Select from './index.js'
+       import * as Select from './index'
 	import { cn } from '$lib/utils.js'
 
 	let {

--- a/src/lib/components/ui/select/select-separator.svelte
+++ b/src/lib/components/ui/select/select-separator.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Separator as SeparatorPrimitive } from 'bits-ui'
-	import { Separator } from '$lib/components/ui/separator/index.js'
+       import { Separator } from '$lib/components/ui/separator'
 	import { cn } from '$lib/utils.js'
 
 	let {

--- a/src/lib/components/ui/sidebar/context.svelte.ts
+++ b/src/lib/components/ui/sidebar/context.svelte.ts
@@ -1,4 +1,4 @@
-import { IsMobile } from '$lib/hooks/is-mobile.svelte.js'
+import { IsMobile } from '$lib/hooks/is-mobile.svelte'
 import { getContext, setContext } from 'svelte'
 import { SIDEBAR_KEYBOARD_SHORTCUT } from './constants.js'
 

--- a/src/lib/components/ui/sidebar/index.ts
+++ b/src/lib/components/ui/sidebar/index.ts
@@ -1,4 +1,4 @@
-import { useSidebar } from './context.svelte.js'
+import { useSidebar } from './context.svelte'
 import Content from './sidebar-content.svelte'
 import Footer from './sidebar-footer.svelte'
 import GroupAction from './sidebar-group-action.svelte'

--- a/src/lib/components/ui/sidebar/sidebar-input.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-input.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Input } from '$lib/components/ui/input/index.js'
+       import { Input } from '$lib/components/ui/input'
 	import { cn } from '$lib/utils.js'
 	import type { ComponentProps } from 'svelte'
 

--- a/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
@@ -30,7 +30,7 @@
 </script>
 
 <script lang="ts">
-	import * as Tooltip from '$lib/components/ui/tooltip/index.js'
+       import * as Tooltip from '$lib/components/ui/tooltip'
 	import { cn } from '$lib/utils.js'
 	import {
 		mergeProps,
@@ -39,7 +39,7 @@
 	} from 'bits-ui'
 	import type { ComponentProps, Snippet } from 'svelte'
 	import type { HTMLAttributes } from 'svelte/elements'
-	import { useSidebar } from './context.svelte.js'
+       import { useSidebar } from './context.svelte'
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/sidebar/sidebar-menu-skeleton.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-skeleton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Skeleton } from '$lib/components/ui/skeleton/index.js'
+       import { Skeleton } from '$lib/components/ui/skeleton'
 	import { cn } from '$lib/utils.js'
 	import type { WithElementRef } from 'bits-ui'
 	import type { HTMLAttributes } from 'svelte/elements'

--- a/src/lib/components/ui/sidebar/sidebar-provider.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-provider.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import * as Tooltip from '$lib/components/ui/tooltip/index.js'
+       import * as Tooltip from '$lib/components/ui/tooltip'
 	import { cn } from '$lib/utils.js'
 	import type { WithElementRef } from 'bits-ui'
 	import type { HTMLAttributes } from 'svelte/elements'
@@ -9,7 +9,7 @@
 		SIDEBAR_WIDTH,
 		SIDEBAR_WIDTH_ICON,
 	} from './constants.js'
-	import { setSidebar } from './context.svelte.js'
+       import { setSidebar } from './context.svelte'
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/sidebar/sidebar-rail.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-rail.svelte
@@ -2,7 +2,7 @@
 	import { cn } from '$lib/utils.js'
 	import type { WithElementRef } from 'bits-ui'
 	import type { HTMLAttributes } from 'svelte/elements'
-	import { useSidebar } from './context.svelte.js'
+       import { useSidebar } from './context.svelte'
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/sidebar/sidebar-separator.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-separator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Separator } from '$lib/components/ui/separator/index.js'
+       import { Separator } from '$lib/components/ui/separator'
 	import { cn } from '$lib/utils.js'
 	import type { ComponentProps } from 'svelte'
 

--- a/src/lib/components/ui/sidebar/sidebar-trigger.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-trigger.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { Button } from '$lib/components/ui/button/index.js'
+       import { Button } from '$lib/components/ui/button'
 	import { cn } from '$lib/utils.js'
 	import PanelLeft from 'lucide-svelte/icons/panel-left'
 	import type { ComponentProps } from 'svelte'
-	import { useSidebar } from './context.svelte.js'
+       import { useSidebar } from './context.svelte'
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/src/lib/components/ui/sidebar/sidebar.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import * as Sheet from '$lib/components/ui/sheet/index.js'
+       import * as Sheet from '$lib/components/ui/sheet'
 	import { cn } from '$lib/utils.js'
 	import type { WithElementRef } from 'bits-ui'
 	import type { HTMLAttributes } from 'svelte/elements'
 	import { SIDEBAR_WIDTH_MOBILE } from './constants.js'
-	import { useSidebar } from './context.svelte.js'
+       import { useSidebar } from './context.svelte'
 
 	let {
 		ref = $bindable(null),

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -3,10 +3,10 @@
 	import type { ArxivQuery, ArxivMetadataList } from '$lib/schemas'
 	import { enhance } from '$app/forms'
 
-	import * as Select from '$lib/components/ui/select/index.js'
+       import * as Select from '$lib/components/ui/select'
 	import { Button } from '$lib/components/ui/button/index'
 	import { Input } from '$lib/components/ui/input/index'
-	import { Label } from '$lib/components/ui/label/index.js'
+       import { Label } from '$lib/components/ui/label'
 
 	import CardLibrary from '$lib/components/search/cardLibrary.svelte'
 


### PR DESCRIPTION
## Summary
- swap `index.js` and `.svelte.js` imports for extensionless paths
- keep TypeScript config the same because `moduleResolution: bundler` already handles extensionless imports

## Testing
- `npm run -s check`