### PR TITLE
Add documentation suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,29 @@
 # By Tomorrow - Research Paper Management App
 
-By Tomorrow is a SvelteKit application for organizing research papers. It lets you search [arXiv](https://arxiv.org), tag papers, and maintain a library for easy reference. The project also includes a custom document editor and PDF viewer to help manage reading notes.
+**By Tomorrow** is a SvelteKit application for organising research papers and notes. It provides a workflow for searching [arXiv](https://arxiv.org), tagging papers, managing a personal library and experimenting with a custom document editor. The code base has been refactored extensively and these README files serve as a guide for future contributors.
 
-## Development setup
+## Quick start
 
-1. Copy `.env.example` to `.env` and adjust the values as needed. The file
-   defines environment variables such as `DATABASE_URL` for Prisma and
-   `VITE_ENABLE_LOGGING` to control console output.
-2. Install dependencies with your preferred package manager (npm or pnpm):
+1. Copy `.env.example` to `.env` and adjust the variables such as `DATABASE_URL` and `VITE_ENABLE_LOGGING`.
+2. Install dependencies with `pnpm install` (or `npm install`).
+3. Initialise the database:
    ```bash
-   pnpm install
-   # or
-   npm install
+   npm run db:push
    ```
-3. Start the development server:
+4. Launch the dev server:
    ```bash
    npm run dev
    ```
-   The app will be available at `http://localhost:5173` by default.
+   Visit [http://localhost:5173](http://localhost:5173) to view the app.
 
-### PDF viewer dependency
+More detailed setup instructions and component documentation live in the [`docs/`](docs/) directory.
 
-The `pdfViewer` component expects a module named `mupdf`. A simple type
-declaration is included at `src/mupdf.d.ts` so the code compiles even when the
-package is missing. To use the real library, install it with your package
-manager:
+## Features
 
-```bash
-pnpm add mupdf
-```
-
-After installing the module you can delete `src/mupdf.d.ts` since the explicit
-type declaration is no longer required.
-
-## Database
-
-The app uses Prisma with a SQLite database. Copy `.env.example` to `.env` and edit
-the variables as needed. `DATABASE_URL` configures the database connection and
-`VITE_ENABLE_LOGGING` can be set to `false` to silence console logs. After
-configuring your environment, initialize the database with:
-```
-npm run db:push
-```
-
-You can open Prisma Studio to explore the data:
-```bash
-npm run db:studio
-```
-
-## Running tests
-
-There are currently no automated tests for this project.
-
-## Roadmap
-
-- Search arXiv and save metadata with custom tags
-- View your paper library and remove entries
+- arXiv search and library management
 - PDF viewer with editable URL input
-- Rich-text editor built with Svedit
-- Upcoming: login flow and file manager
+- Experimental editor built with the in‑house **Svedit** framework
 
 ## License
 
-This project is licensed under the Creative Commons Attribution-NonCommercial 4.0 International License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the Creative Commons Attribution‑NonCommercial 4.0 International License. See [LICENSE](LICENSE) for details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation Overview
+
+This `docs/` directory contains reference material for developers working on **By Tomorrow**. These documents explain the repository layout, development setup, and provide detailed information about the major Svelte components used throughout the app.
+
+- [development.md](development.md) – step‑by‑step guide for getting the project running locally and managing the database.
+- [components.md](components.md) – catalog of the main Svelte components, features and routes.
+- [roadmap.md](roadmap.md) – short‑term goals and longer term ideas for future work.
+
+Each file can be read on its own or browsed together as a mini handbook.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,22 @@
+# Component Reference
+
+This page describes the most important Svelte components and routes. The application is split into modes – **search**, **library**, **reader** and **editor** – each implemented as a dedicated route under `src/routes`.
+
+## Routes
+
+- `/search` – query the arXiv API and save papers to the local library. The server side logic resides in [`src/routes/search/+page.server.ts`](../src/routes/search/+page.server.ts). Client side rendering is handled in [`src/routes/search/+page.svelte`](../src/routes/search/+page.svelte). The search results are displayed with `PaperCard` components and can be bulk tagged before saving to the library.
+- `/library` – view saved paper metadata. The table UI is implemented in [`src/lib/components/library/libraryTable.svelte`](../src/lib/components/library/libraryTable.svelte) and the server actions in [`src/routes/library/+page.server.ts`](../src/routes/library/+page.server.ts).
+- `/reader` – simple PDF viewer that lets you specify a URL. See [`src/routes/reader/+page.svelte`](../src/routes/reader/+page.svelte).
+- `/editor` – experimental document editor based on the custom **Svedit** framework. The entry page is [`src/routes/editor/+page.svelte`](../src/routes/editor/+page.svelte).
+
+## Svedit
+
+The editor used in `/editor` is built from the files under [`src/lib/svedit`](../src/lib/svedit). A `SveditSession` manages the root `BlockData` and tracks undo/redo history. Blocks can be nested and support Markdown rendering. See [`src/lib/svedit/BlockData.svelte.ts`](../src/lib/svedit/BlockData.svelte.ts) for the block model and [`src/lib/svedit/Svedit.svelte`](../src/lib/svedit/Svedit.svelte) for the top level component.
+
+## UI components
+
+Reusable UI primitives live under [`src/lib/components/ui`](../src/lib/components/ui). They mirror the structure of component libraries like Radix UI and are re‑exported as needed. Higher level components, such as the sidebar and cards used throughout the app, can be found in `src/lib/components`.
+
+## Database
+
+Prisma models are defined in [`prisma/schema.prisma`](../prisma/schema.prisma). At the moment there is a single `PaperMetadataLibrary` table holding arXiv metadata and tags. The helper functions in [`src/lib/database.ts`](../src/lib/database.ts) perform upserts and transactional updates.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,40 @@
+# Development Guide
+
+This file expands on the quick start instructions from the project root `README.md`. It covers environment variables, package management and database commands in more depth.
+
+## Environment setup
+
+1. Copy `.env.example` to `.env` and adjust the values. The important variables are:
+   - `DATABASE_URL` – connection string used by Prisma. SQLite is used by default.
+   - `VITE_ENABLE_LOGGING` – set to `false` to silence `logger` output.
+2. Install Node dependencies. Either `pnpm` or `npm` will work:
+   ```bash
+   pnpm install
+   # or
+   npm install
+   ```
+3. Push the Prisma schema and create the SQLite database:
+   ```bash
+   npm run db:push
+   ```
+4. Start the development server with hot reloading:
+   ```bash
+   npm run dev
+   ```
+   The app is served on [http://localhost:5173](http://localhost:5173).
+
+### Database utilities
+
+- `npm run db:studio` – open [Prisma Studio](https://www.prisma.io/studio) in the browser to inspect and modify local data.
+- `npm run db:migrate` – create and run a migration when the schema changes.
+- `npm run db:start` – start the optional Postgres container defined in `docker-compose.yml` if you prefer Postgres over SQLite.
+
+### PDF viewer dependency
+
+The PDF viewer component requires the [`mupdf`](https://www.npmjs.com/package/mupdf) package. A placeholder type declaration exists at `src/mupdf.d.ts` so compilation succeeds even when the package is missing. If you wish to try the real library run:
+
+```bash
+pnpm add mupdf
+```
+
+and remove the placeholder type file.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,16 @@
+# Roadmap
+
+The project is still evolving. The short term focus is on improving paper management and iterating on the editor. Longer term goals aim to make By Tomorrow a full research workflow companion.
+
+## Near term
+
+- Polish the arXiv search interface and add filters.
+- Extend the library view with pagination and per-paper actions.
+- Add authentication and user accounts.
+- Expand the Svedit editor with drag–and–drop reordering.
+
+## Future ideas
+
+- Integrate local file uploads and annotate PDFs directly in the reader mode.
+- Collaborative editing and shared libraries.
+- Richer tagging and querying across documents and notes.


### PR DESCRIPTION
## Summary
- add a new `docs/` directory with developer and component guides
- simplify the root README and link to the new docs

## Testing
- `npm run check`
